### PR TITLE
Changed variable names to be consistent

### DIFF
--- a/docs/programming/MPI-Fortran.md
+++ b/docs/programming/MPI-Fortran.md
@@ -102,7 +102,7 @@ processes and the rank of a given process respectively:
 PROGRAM hello_world_mpi
 include 'mpif.h'
 
-integer process_Rank, size_Of_Cluster, ierror
+integer rank, size, ierror
 
 call MPI_INIT(ierror)
 call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierror)


### PR DESCRIPTION
Changed 'process_Rank' and 'size_of_Cluster' to 'rank' and 'size' in type declaration to match main body of code and following examples. However 'size' is a Fortran built-in function, so maybe it is not the best name for a variable.