### PR TITLE
Update alpine-hardware.md

### DIFF
--- a/docs/clusters/alpine/alpine-hardware.md
+++ b/docs/clusters/alpine/alpine-hardware.md
@@ -16,75 +16,9 @@
 
 ### Requesting Hardware Resources
 Resources are requested within jobs by passing in SLURM directives, or resource flags, to either a job script (most common) or to the command line when submitting a job. Below are some common resource directives for Alpine (summarized then detailed):
-* **Partition:** Specifies node type
 * **Gres (General Resources):** Specifies the number of GPUs (*required if using a GPU node*)
 * **QOS (Quality of Service):** Constrains or modifies job characteristics
-
-
-#### Partitions
-
-**Nodes with the same hardware configuration are grouped into partitions**. You specify a partition using `--partition` SLURM directive in your job script (or at the command line when submitting an interactive job) in order for your job to run on the appropriate type of node. 
-
-> **Note:** GPU nodes require the additional `--gres` directive (see next section).
-
-Partitions available on Alpine:
-
-
-| Partition | Description                  | # of nodes | cores/node | RAM/core (GB) | Billing weight | Default/Max Walltime     |
-| --------- | ---------------------------- | ---------- | ---------- | ------------- | -------------- | ------------------------ |
-| amilan    | AMD Milan (default)          | 184        | 64         |   3.75        | 1              | 24H, 24H                 |
-| ami100    | GPU-enabled (3x AMD MI100)   | 8          | 64         |   3.75        | tbd            | 24H, 24H                 |
-| aa100     | GPU-enabled (3x NVIDIA A100) | 8          | 64         |   3.75        | tbd            | 24H, 24H                 |
-| amem<sup>1</sup> | High-memory           | 4          | 48         |  20.83<sup>2</sup>        | tbd            |  4H,  7D                 |
-| csu       | Nodes contributed by CSU     | 77         | 32 or 48   |   3.75        | 1              | 24H, 24H                 |
-
-<sup>1</sup>The `amem` partition requires the mem QOS. The mem QOS is only available to jobs asking for 256GB of RAM or more, 12 nodes or fewer, and 96 cores or fewer. For example, you can run one 96-core job or up to two 48-core jobs, etc. If you need more memory or cores, please contact <rc-help@colorado.edu>.
-
-<sup>2</sup>On the `amem` partition, if you request all 48 cores on a node without specifying the `--mem` flag, you will receive 1000 GB (1024000 MB) of RAM on the node.  Because of the way slurm handles units conversions, if you use the `--mem` flag, the maximum RAM you can request is 976.5 GB (1000000 MB) RAM.  
-
-> * Note: NVIDIA A100 GPUs only support CUDA versions >11.x
-
-All users, regardless of institution, should specify partitions as follows:
-```bash
---partition=amilan
---partition=aa100
---partition=ami100
---partition=amem
---partition=csu
-```
-
-**Special-purpose partitions**
-
-`atesting` provides access to limited resources for the purpose of verifying workflows and MPI jobs. Users are able to request up to 2 CPU nodes (16 cores per node) for a maximum runtime of 3 hours (default 30 minutes). Users who need GPU nodes to test workflows should use the appropriate GPU partition (`ami100` or `aa100`) instead of `atesting`.
-
-`atesting` usage examples:
-
-_Request one core per node for 10 minutes_
-```
-sinteractive --partition=atesting --ntasks-per-node=1 --qos=testing --nodes=2 --time=00:10:00
-```
-_Request 4 cores for the default time of 30 minutes_
-```
-sinteractive --partition=atesting --qos=testing --ntasks=4  
-```
-_Request 2 cores each from 2 nodes for testing MPI_
-```
-sinteractive --ntasks-per-node=2 --nodes=2 --partition=atesting --qos=testing
-```
-
-`acompile` provides near immediate access to limited resources for the purpose of compiling and viewing the module stack. Users can request up to 4 CPU cores (but no GPUs) for a maximum runtime of 12 hours. The partition is accessed with the `acompile` command. Users who need GPU nodes to compile software should use Slurm's `sinteractive` command with the appropriate GPU partition (`ami100` or `aa100`) instead of `acompile`.
-
-`acompile` usage examples:
-
-_Get usage information for_ `acompile`
-```
-acompile --help
-```
-_Request 2 CPU cores for 2 hours_
-```
-acompile --ntasks=2 --time=02:00:00
-```
-
+* * **Partition:** Specifies node type
 
 #### General Resources (gres)
 
@@ -116,6 +50,86 @@ The available QoS's for Alpine are:
 | normal      | Default                    | 1D              | tbd           | tbd                | n/a              | 0                    |
 | long        | Longer wall times          | 7D              | tbd           | tbd                | tbd              | 0                    |
 | mem         | High-memory jobs           | 7D              | tbd           | 12                 | amem only        | 0                    |
+
+
+#### Partitions
+
+**Nodes with the same hardware configuration are grouped into partitions**. You specify a partition using `--partition` SLURM directive in your job script (or at the command line when submitting an interactive job) in order for your job to run on the appropriate type of node. 
+
+> **Note:** GPU nodes require the additional `--gres` directive (see above section).
+
+Partitions available on Alpine:
+
+
+| Partition | Description                  | # of nodes | cores/node | RAM/core (GB) | Billing weight | Default/Max Walltime     |
+| --------- | ---------------------------- | ---------- | ---------- | ------------- | -------------- | ------------------------ |
+| amilan    | AMD Milan (default)          | 283        | 64         |   3.75        | 1              | 24H, 24H                 |
+| ami100    | GPU-enabled (3x AMD MI100)   | 8          | 64         |   3.75        | tbd            | 24H, 24H                 |
+| aa100     | GPU-enabled (3x NVIDIA A100) | 12          | 64         |   3.75        | tbd            | 24H, 24H                 |
+| amem<sup>1</sup> | High-memory           | 12          | 48         |  20.83<sup>2</sup>        | tbd            |  4H,  7D                 |
+| csu       | Nodes contributed by CSU     | 77         | 32 or 48   |   3.75        | 1              | 24H, 24H                 |
+
+<sup>1</sup>The `amem` partition requires the mem QOS. The mem QOS is only available to jobs asking for 256GB of RAM or more, 12 nodes or fewer, and 96 cores or fewer. For example, you can run one 96-core job or up to two 48-core jobs, etc. If you need more memory or cores, please contact <rc-help@colorado.edu>.
+
+<sup>2</sup>On the `amem` partition, if you request all 48 cores on a node without specifying the `--mem` flag, you will receive 1000 GB (1024000 MB) of RAM on the node.  Because of the way slurm handles units conversions, if you use the `--mem` flag, the maximum RAM you can request is 976.5 GB (1000000 MB) RAM.  
+
+> * Note: NVIDIA A100 GPUs only support CUDA versions >11.x
+
+All users, regardless of institution, should specify partitions as follows:
+```bash
+--partition=amilan
+--partition=aa100
+--partition=ami100
+--partition=amem
+--partition=csu
+```
+
+**Special-purpose partitions**
+
+`atesting` provides access to limited resources for the purpose of verifying workflows and MPI jobs. Users are able to request up to 2 CPU nodes (16 cores per node) for a maximum runtime of 3 hours (default 30 minutes). Users who need GPU nodes to test workflows should use the appropriate GPU testing partitions (`atesting_a100` or `atesting_mi100`) instead of `atesting`.
+
+`atesting` usage examples:
+
+_Request one core per node for 10 minutes_
+```
+sinteractive --partition=atesting --ntasks-per-node=1 --nodes=2 --time=00:10:00
+```
+_Request 4 cores for the default time of 30 minutes_
+```
+sinteractive --partition=atesting --ntasks=4  
+```
+_Request 2 cores each from 2 nodes for testing MPI_
+```
+sinteractive --ntasks-per-node=2 --nodes=2 --partition=atesting 
+```
+
+`atesting_a100` and `atesting_mi100` provide access to limited GPU resources for the purpose of verifying GPU workflows and building GPU-accelerated applications. Users can request up to 3 GPUs and all associated CPU cores (64 max) from a single node for up to one hour (default one hour).
+
+Usage examples:
+
+_Request 2 A100 GPUs with 40 CPU cores for 30 minutes._
+```
+sinteractive --partition=atesting_a100 --gres=gpu:2 --ntasks=40 --time=30:00
+```
+_Request 1 MI100 GPU with 1 CPU core for one hour._
+```
+sinteractive --partition=atesting_a100 --gres=gpu:2 --ntasks=2 --time=60:00
+```
+
+
+`acompile` provides near-immediate access to limited resources for the purpose of viewing the module stack and compiling software. Users can request up to 4 CPU cores (but no GPUs) for a maximum runtime of 12 hours. The partition is accessed with the `acompile` command. Users who need GPU nodes to compile software should use Slurm's `sinteractive` command with the appropriate GPU partition (`ami100` or `aa100`) instead of `acompile`.
+
+`acompile` usage examples:
+
+_Get usage information for_ `acompile`
+```
+acompile --help
+```
+_Request 2 CPU cores for 2 hours_
+```
+acompile --ntasks=2 --time=02:00:00
+```
+
 
 Alpine is jointly funded by the University of Colorado Boulder, the University of Colorado Anschutz, Colorado State University, and the National Science Foundation (award 2201538).
 


### PR DESCRIPTION
- adding two new GPU testing partitions 
- changed order of partition sections so that gres and qos come before partition
- removing `--qos=testing` from `atesting` usage examples (we've since modified slurm settings to default to testing for atesting) 
- updated node counts in the partition table