### PR TITLE
correct path to /scratch/alpine and updated CSU login page

### DIFF
--- a/docs/access/logging-in.md
+++ b/docs/access/logging-in.md
@@ -15,7 +15,7 @@ Users accessing RC's resources will be connected to a login node. A login node i
 
 > **Note:** the [login node policy](https://github.com/ResearchComputing/Documentation/edit/master/docs/compute/node-types.md#policy-for-use-of-login-nodes) states that login nodes should not be used for resource-intensive tasks such as running code. For all other tasks, users should run batch jobs, interactive jobs, or use the compile nodes. 
 
-+ **For CSU users, please refer to the [CSU login guide.](https://www.acns.colostate.edu/hpc/#remote-login)**  
++ **For CSU users, please refer to the "Remote Login" section of CSU's [Get Started with Alpine](https://it.colostate.edu/research-computing-and-cyberinfrastructure/compute/get-started-with-alpine/#) page.**  
 + **For RMACC users, pleaser refer to [RMACC Access to Alpine.](rmacc.html)**
 
 ---

--- a/docs/additional-resources/policies.md
+++ b/docs/additional-resources/policies.md
@@ -72,7 +72,7 @@ Computing resources.
 
 ### Alpine scratch quota increases
 
-Each user is allocated 10 TB in `/alpine/scratch/`. Users requiring more than 10 TB may request a supplemental space allocation by 
+Each user is allocated 10 TB in `/scratch/alpine`. Users requiring more than 10 TB may request a supplemental space allocation by 
 submitting a brief (approximately one paragraph) justification. The justification should describe why a group's workflow requires 
 the requested amount.
 


### PR DESCRIPTION
Stakeholders requested the following edits:
-fix path to alpine scratch in policies.md
-update link to CSU login instructions at logging-in.md