### PR TITLE
Add DOI and citations for core services 

### DIFF
--- a/docs/clusters/summit/summit.md
+++ b/docs/clusters/summit/summit.md
@@ -10,3 +10,5 @@ Users needing to acknowledge the Summit supercomputer in publications may use th
 
 "This work utilized the RMACC Summit supercomputer, which is supported by the National Science Foundation (awards ACI-1532235 and ACI-1532236), the University of Colorado Boulder, and Colorado State University. The Summit supercomputer is a joint effort of the University of Colorado Boulder and Colorado State University."
 
+- DOI: <https://doi.org/10.25811/8np0-je59>
+- Citation: University of Colorado Boulder Research Computing. (2021). RMACC Summit Supercomputer. University of Colorado Boulder. <https://doi.org/10.25811/8np0-je59>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,17 +40,29 @@ Use of University of Colorado Research Computing resources, including (but not l
 **Acknowledging Alpine:**
 “This work utilized the Alpine high performance computing resource at the University of Colorado Boulder. Alpine is jointly funded by the University of Colorado Boulder, the University of Colorado Anschutz, Colorado State University, and the National Science Foundation (award 2201538).”
 
+- DOI: https://doi.org/10.25811/k3w6-pk81 
+- Citation: University of Colorado Boulder Research Computing. (2023). Alpine. University of Colorado Boulder. https://doi.org/10.25811/k3w6-pk81
+
 **Acknowledging Cumulus:**
 "This work utilized the CUmulus on-premise cloud service at the University of Colorado Boulder. CUmulus is jointly funded by the National Science Foundation (award OAC-1925766) and the University of Colorado Boulder."
 
 **Acknowledging Summit:**
 "This work utilized the Summit supercomputer, which is supported by the National Science Foundation (awards ACI-1532235 and ACI-1532236), the University of Colorado Boulder, and Colorado State University. The Summit supercomputer is a joint effort of the University of Colorado Boulder and Colorado State University."
 
+- DOI: https://doi.org/10.25811/8np0-je59
+- Citation: University of Colorado Boulder Research Computing. (2021). RMACC Summit Supercomputer. University of Colorado Boulder. https://doi.org/10.25811/8np0-je59
+
 **Acknowledging Blanca:**
 "This work utilized the Blanca condo computing resource at the University of Colorado Boulder. Blanca is jointly funded by computing users and the University of Colorado Boulder."
 
+- DOI: https://doi.org/10.25811/v32c-gy42
+- Citation: University of Colorado Boulder Research Computing. (2021). Blanca Condo Cluster. University of Colorado Boulder. https://doi.org/10.25811/v32c-gy42
+
 **Acknowledging PetaLibrary:**
 "Data storage supported by the University of Colorado Boulder 'PetaLibrary'"
+
+- DOI: https://doi.org/10.25811/81nc-wv41
+- Citation: University of Colorado Boulder Research Computing. (2021). PetaLibrary. University of Colorado Boulder. https://doi.org/10.25811/81nc-wv41
 
 ----
 


### PR DESCRIPTION
This PR adds DOIs and citations for Alpine, Blanca, Summit, and PetaLibrary. This will now allow our users to easily acknowledge that they used our services to complete their research. 