### PR TITLE
Update max cores for `atesting` partition

### DIFF
--- a/docs/clusters/alpine/alpine-hardware.md
+++ b/docs/clusters/alpine/alpine-hardware.md
@@ -89,7 +89,7 @@ All users, regardless of institution, should specify partitions as follows:
 
 **Special-purpose partitions**
 
-`atesting` provides access to limited resources for the purpose of verifying workflows and MPI jobs. Users are able to request up to 2 CPU nodes (16 cores per node) for a maximum runtime of 3 hours (default 30 minutes). Users who need GPU nodes to test workflows should use the appropriate GPU testing partitions (`atesting_a100` or `atesting_mi100`) instead of `atesting`.
+`atesting` provides access to limited resources for the purpose of verifying workflows and MPI jobs. Users are able to request up to 2 CPU nodes (8 cores per node) for a maximum runtime of 3 hours (default 30 minutes) and 16 CPUs. Users who need GPU nodes to test workflows should use the appropriate GPU testing partitions (`atesting_a100` or `atesting_mi100`) instead of `atesting`.
 
 `atesting` usage examples:
 

--- a/docs/running-jobs/batch-jobs.md
+++ b/docs/running-jobs/batch-jobs.md
@@ -152,15 +152,14 @@ export OMP_NUM_THREADS=4
 ./example_omp.exe
 ```
 
-Job script to run a 10 minute long, 2 node, 24 core C++ MPI Job:
+Job script to run a 10 minute long, 2 node, 16 core C++ MPI Job:
 
 ```bash
 #!/bin/bash
 
 #SBATCH --nodes=2
 #SBATCH --time=00:10:00
-#SBATCH --partition=atesting
-#SBATCH --ntasks=24
+#SBATCH --partition=atesting#SBATCH --ntasks=16
 #SBATCH --job-name=mpi-cpp-job
 #SBATCH --output=mpi-cpp-job.%j.out
 
@@ -168,7 +167,7 @@ module purge
 module load intel
 module load impi
 
-mpirun -np 24 ./example_mpi.exe
+mpirun -np 16 ./example_mpi.exe
 ```
 
 ### Job Flags

--- a/docs/running-jobs/job-resources.md
+++ b/docs/running-jobs/job-resources.md
@@ -43,11 +43,11 @@ In addition to these partitions, Research Computing also provides specialized pa
 
 | Partition        | Description       | Max Nodes | Max cores | Billing wgt/core | Default/Max Walltime     |
 | ---------------- | ----------------- | --------- | --------- | ---------------- | ------------------------ |
-| atesting <sup>3</sup> | Testing      | Up to 2   | 32        | 0.25             | 0.5H, 3H                 |
+| atesting <sup>3</sup> | Testing      | Up to 2   | 16        | 0.25             | 0.5H, 3H                 |
 | acompile         | Compile           | 1         | 4         | 1.0              | 1H, 12H                  |
 | ainteractive     | Interactive Jobs  | 1         | 1         | 1.0              | 1H, 12H                  |
 
-> <sup>3</sup> The `atesting` partition is limited to 32 cores total. These cores can come from up to 2 nodes, but a user is limited to maximum of 32 cores per job.
+> <sup>3</sup> The `atesting` partition is limited to 16 cores total. These cores can come from up to 2 nodes, but a user is limited to maximum of 16 cores per job.
 
 To run a job longer than 24 hours on the `amilan`, `ami100`, or `aa100` partitions, use the `long` QOS.
 


### PR DESCRIPTION
In this PR I change all documentation associated with the atesting partition, such that we communicate that we are limiting users to 16 cores and 2 nodes. 