### PR TITLE
Typo in example code inside MPI-C.md

### DIFF
--- a/docs/programming/MPI-C.md
+++ b/docs/programming/MPI-C.md
@@ -95,7 +95,7 @@ which will initialize the mpi communicator:
 #include <mpi.h>
 
 int main(int argc, char** argv){
-    int process_Rank, size_Of_Cluster
+    int process_Rank, size_Of_Cluster;
 
     MPI_Init(&argc, &argv);
 


### PR DESCRIPTION
There is a typo in example code inside MPI-C.md
```c++
int process_Rank, size_Of_Cluster
```

There should be semicolon:
```c++
int process_Rank, size_Of_Cluster;
```