### PR TITLE
Updated `conda_dev_env.yml`

### DIFF
--- a/conda_dev_env.yml
+++ b/conda_dev_env.yml
@@ -1,4 +1,4 @@
-name: rc-docs-new-theme
+name: rc-docs
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
This PR resolves issue #322. Changes were made to the conda_dev_env.yml file so that the conda environment create is named `rc-docs`. Previously it was listed as `rc-docs-new-theme`. 