### PR TITLE
Resolved MPI-Fortran-Typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 .DS_Store
+
+.vscode/

--- a/docs/programming/MPI-Fortran.md
+++ b/docs/programming/MPI-Fortran.md
@@ -289,7 +289,7 @@ DO i = 0, 3, 1
     IF(i == process_Rank) THEN
         print *, 'Hello World from process: ', process_Rank, 'of ', size_Of_Cluster
     END IF
-    call MPI_BARRIER( MPI_COMM_WORLD, i_error)
+    call MPI_BARRIER( MPI_COMM_WORLD, ierror)
 END DO
 
 call MPI_FINALIZE(ierror)

--- a/docs/programming/coding-best-practices.md
+++ b/docs/programming/coding-best-practices.md
@@ -133,6 +133,7 @@ comments vs. comments.
 .. tabs::
 
    .. code-tab:: c++ No comments 
+      :caption: This notation describes the variable type or purpose at the start of the variable name, followed by a descriptor that indicates the variable’s function. The Camelcase notation is used to delimit. [text with attributes]{.bg-warning}
 
         #include <stdio.h>
         #include <vector>

--- a/docs/programming/coding-best-practices.md
+++ b/docs/programming/coding-best-practices.md
@@ -133,7 +133,6 @@ comments vs. comments.
 .. tabs::
 
    .. code-tab:: c++ No comments 
-      :caption: This notation describes the variable type or purpose at the start of the variable name, followed by a descriptor that indicates the variable’s function. The Camelcase notation is used to delimit. [text with attributes]{.bg-warning}
 
         #include <stdio.h>
         #include <vector>


### PR DESCRIPTION
This PR resolves the issue #312. Changes were made to the `MPI-Fortran-md` where the call to `MPI_BARRIER` in the uses the argument `i_error` instead of the defined `ierror`. 