### PR TITLE
Add CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+
+# Contributing to documentation
+
+At CU Research Computing (CURC) we welcome all contributions to our documentation. To contribute to our documentation, you can submit an issue or a pull request. For more information on submitting an issue or pull request, and specific documentation guidelines, please see our [Contributing to CURC Documentation](https://curc.readthedocs.io/en/latest/additional-resources/contrib_curc_docs.html) page. 


### PR DESCRIPTION
In this PR I add a `CONTRIBUTING.md` page to the repo. It is standard practice to include a `CONTRIBUTING.md` that tells individuals how they can contribute to a repo. The `CONTRIBUTING.md` page I added directs individuals to our `Contributing to CURC Documentation` page that describes how to create an issue, submit a pull request, and specific guidelines that should be followed when creating documentation. 