### PR TITLE
Add Spring 2025 RC Training Events 

### DIFF
--- a/docs/getting_started/current-sem-trainings.md
+++ b/docs/getting_started/current-sem-trainings.md
@@ -62,7 +62,7 @@ Click the name of a training to view more details and register!
 - [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/alpine_new) - **January 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
 - [Working with Linux on HPC (an RC Short Course)](https://colorado.libcal.com/calendar/events/linux) - **January 29th, 11am, Hybrid (Norlin Library E206/Zoom)**
 - [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 7th, 10am, Virtual (Zoom)**
 - [Research Storage Simplified (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/storage) - **March 19th, 11am, Virtual (Zoom)**
 
 ### **Intermediate**

--- a/docs/getting_started/current-sem-trainings.md
+++ b/docs/getting_started/current-sem-trainings.md
@@ -11,25 +11,23 @@ Click the name of a training to view more details and register!
 ````{tab-item} By Month
 :sync: cur-sem-train-by-month
 
-### **August**
-- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/newuser) - **August 28th, 2pm, Hybrid (Norlin Library E206/Zoom)**
-### **September**
-- [Supercomputing Spin Up: Part 1--Working with Linux (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt1) - **September 3rd, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Supercomputing Spin Up: Part 2--Job Submission (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt2) - **September 5th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Git & GitHub In-Depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/githubsc) - **September 17th, 10am, Hybrid (Norlin Library E206/Zoom)**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **September 18th, 11am, Zoom**
-- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **September 24th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Debugging with VS Code (an RC Short Course)](https://colorado.libcal.com/calendar/events/vscode) - **September 26th, 11am, Hybrid (Norlin Library E206/Zoom)**
-### **October**
-- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **October 8th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **October 10th, 12:30pm, Zoom**
-- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **October 17th, 12pm, Zoom**
-- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud101) - **October 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
-### **November**
-- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **November 4th, 3pm, Zoom**
-- [AlphaFold2 on Alpine (an RC Short Course)](https://colorado.libcal.com/calendar/events/alphafold) - **November 11th, 10am, Hybrid (Norlin Library E206/Zoom)**
-- [Build Chatbots with Amazon Bedrock Knowledge Bases and Agents (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/chatbots) - **November 12th, 10am, Zoom**
-- [Building with Generative AI Apps on AWS (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/aiapps) - **November 19th, 10am, Zoom**
+### **January**
+- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/alpine_new) - **January 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Working with Linux on HPC (an RC Short Course)](https://colorado.libcal.com/calendar/events/linux) - **January 29th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
+### **February**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
+- [Git & GitHub In-depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/github) - **February 18th, 10am, Hybrid (Norlin Library E206/Zoom)**
+- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **February 26th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+- [Introducing Research Computing’s new NVIDIA Grace Hopper Superchip (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/hopper) - **February 27th, 12pm, Virtual (Zoom)**
+### **March**
+- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **March 3rd, 12pm, Hybrid (Norlin Library E206/Zoom)**
+- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **March 5th, 2pm, Virtual (Zoom)**
+- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **March 7th, 10am, Virtual (Zoom)**
+- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud) - **March 12th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+- [Research Storage Simplified (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/storage) - **March 19th, 11am, Virtual (Zoom)**
+### **April**
+- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **April 4th, 10am, Hybrid (Norlin Library E206/Zoom)**
 
 ````
 
@@ -37,50 +35,48 @@ Click the name of a training to view more details and register!
 :sync: cur-sem-train-by-topic
 
 ### **CU Research Computing Fundamentals**
-- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/newuser) - **August 28th, 2pm, Hybrid (Norlin Library E206/Zoom)**
-- [Supercomputing Spin Up: Part 1--Working with Linux (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt1) - **September 3rd, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Supercomputing Spin Up: Part 2--Job Submission (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt2) - **September 5th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/alpine_new) - **January 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Working with Linux on HPC (an RC Short Course)](https://colorado.libcal.com/calendar/events/linux) - **January 29th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Research Storage Simplified (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/storage) - **March 19th, 11am, Virtual (Zoom)**
 ### **Installing Software**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **September 18th, 11am, Zoom**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
 ### **Version Control & Debugging**
-- [Git & GitHub In-Depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/githubsc) - **September 17th, 10am, Hybrid (Norlin Library E206/Zoom)**
-- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **September 24th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Debugging with VS Code (an RC Short Course)](https://colorado.libcal.com/calendar/events/vscode) - **September 26th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **October 8th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Git & GitHub In-depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/github) - **February 18th, 10am, Hybrid (Norlin Library E206/Zoom)**
+- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **February 26th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **March 3rd, 12pm, Hybrid (Norlin Library E206/Zoom)**
 ### **Parallelization & Acceleration**
-- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **October 8th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **October 10th, 12:30pm, Zoom**
-- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **October 17th, 12pm, Zoom**
-- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **November 4th, 3pm, Zoom**
+- [Introducing Research Computing’s new NVIDIA Grace Hopper Superchip (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/hopper) - **February 27th, 12pm, Virtual (Zoom)**
+- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **March 5th, 2pm, Virtual (Zoom)**
+- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **March 7th, 10am, Virtual (Zoom)**
+- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **April 4th, 10am, Hybrid (Norlin Library E206/Zoom)**
 ### **Cloud Computing**
-- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud101) - **October 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Build Chatbots with Amazon Bedrock Knowledge Bases and Agents (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/chatbots) - **November 12th, 10am, Zoom**
-- [Building with Generative AI Apps on AWS (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/aiapps) - **November 19th, 10am, Zoom**
-### **Biology/Bioinformatics**
-- [AlphaFold2 on Alpine (an RC Short Course)](https://colorado.libcal.com/calendar/events/alphafold) - **November 11th, 10am, Hybrid (Norlin Library E206/Zoom)**
+- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud) - **March 12th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+
 ````
 
 ````{tab-item} By Difficulty
 :sync: cur-sem-train-by-diff
 
 ### **Getting Started**
-- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/newuser) - **August 28th, 2pm, Hybrid (Norlin Library E206/Zoom)**
-- [Supercomputing Spin Up: Part 1--Working with Linux (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt1) - **September 3rd, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Supercomputing Spin Up: Part 2--Job Submission (an RC Short Course)](https://colorado.libcal.com/calendar/events/supercomputingpt2) - **September 5th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **September 18th, 11am, Zoom**
-- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud101) - **October 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Alpine New User Seminar (an RC Primer)](https://colorado.libcal.com/calendar/events/alpine_new) - **January 22nd, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Working with Linux on HPC (an RC Short Course)](https://colorado.libcal.com/calendar/events/linux) - **January 29th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
+- [Research Storage Simplified (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/storage) - **March 19th, 11am, Virtual (Zoom)**
+
 ### **Intermediate**
-- [Git & GitHub In-Depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/githubsc) - **September 17th, 10am, Hybrid (Norlin Library E206/Zoom)**
-- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **September 24th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Debugging with VS Code (an RC Short Course)](https://colorado.libcal.com/calendar/events/vscode) - **September 26th, 11am, Hybrid (Norlin Library E206/Zoom)**
-- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **October 10th, 12:30pm, Zoom**
-- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **October 17th, 12pm, Zoom**
-- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **November 4th, 3pm, Zoom**
-- [AlphaFold2 on Alpine (an RC Short Course)](https://colorado.libcal.com/calendar/events/alphafold) - **November 11th, 10am, Hybrid (Norlin Library E206/Zoom)**
-- [Build Chatbots with Amazon Bedrock Knowledge Bases and Agents (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/chatbots) - **November 12th, 10am, Zoom**
-- [Building with Generative AI Apps on AWS (an RC Workshop with AWS)](https://colorado.libcal.com/calendar/events/aiapps) - **November 19th, 10am, Zoom**
+- [Git & GitHub In-depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/github) - **February 18th, 10am, Hybrid (Norlin Library E206/Zoom)**
+- [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **February 26th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+- [Introducing Research Computing’s new NVIDIA Grace Hopper Superchip (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/hopper) - **February 27th, 12pm, Virtual (Zoom)**
+- [Maximizing Efficiency Using Parallelization (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/parallel) - **March 5th, 2pm, Virtual (Zoom)**
+- [Incredibly Easy Parallelization: High Throughput Computing (an RC Primer)](https://colorado.libcal.com/calendar/events/hpcparallel) - **March 7th, 10am, Virtual (Zoom)**
+- [Introduction to the Commercial Cloud (an RC Primer)](https://colorado.libcal.com/calendar/events/cloud) - **March 12th, 2pm, Hybrid (Norlin Library E206/Zoom)**
+- [Introduction to GPU Acceleration on Alpine (an RC Primer)](https://colorado.libcal.com/calendar/events/gpuacceleration) - **April 4th, 10am, Hybrid (Norlin Library E206/Zoom)**
+
 ### **Advanced**
-- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **October 8th, 11am, Hybrid (Norlin Library E206/Zoom)**
+- [Using Linaro DDT on Alpine to Debug Parallel Code (an RC Primer)](https://colorado.libcal.com/calendar/events/linaro) - **March 3rd, 12pm, Hybrid (Norlin Library E206/Zoom)**
+
 ````
 
 ````{tab-item} Office Hours

--- a/docs/getting_started/current-sem-trainings.md
+++ b/docs/getting_started/current-sem-trainings.md
@@ -16,7 +16,7 @@ Click the name of a training to view more details and register!
 - [Working with Linux on HPC (an RC Short Course)](https://colorado.libcal.com/calendar/events/linux) - **January 29th, 11am, Hybrid (Norlin Library E206/Zoom)**
 - [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
 ### **February**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 7th, 10am, Virtual (Zoom)**
 - [Git & GitHub In-depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/github) - **February 18th, 10am, Hybrid (Norlin Library E206/Zoom)**
 - [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **February 26th, 2pm, Hybrid (Norlin Library E206/Zoom)**
 - [Introducing Research Computing’s new NVIDIA Grace Hopper Superchip (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/hopper) - **February 27th, 12pm, Virtual (Zoom)**

--- a/docs/getting_started/current-sem-trainings.md
+++ b/docs/getting_started/current-sem-trainings.md
@@ -40,7 +40,7 @@ Click the name of a training to view more details and register!
 - [Scheduling Jobs on a SuperComputer (an RC Short Course)](https://colorado.libcal.com/calendar/events/jobssc) - **January 31st, 11am, Hybrid (Norlin Library E206/Zoom)**
 - [Research Storage Simplified (an RC Quick Byte)](https://colorado.libcal.com/calendar/events/storage) - **March 19th, 11am, Virtual (Zoom)**
 ### **Installing Software**
-- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 5th, 10am, Virtual (Zoom)**
+- [Installing Software on Alpine with Conda and Mamba (an RC Primer)](https://colorado.libcal.com/calendar/events/conda) - **February 7th, 10am, Virtual (Zoom)**
 ### **Version Control & Debugging**
 - [Git & GitHub In-depth (an RC Short Course)](https://colorado.libcal.com/calendar/events/github) - **February 18th, 10am, Hybrid (Norlin Library E206/Zoom)**
 - [An Introduction to Debugging Techniques (an RC Short Course)](https://colorado.libcal.com/calendar/events/debugging) - **February 26th, 2pm, Hybrid (Norlin Library E206/Zoom)**


### PR DESCRIPTION
In this PR, I have updated the "Current Semester Trainings" page to list the Spring 2025 training events. 