### PR TITLE
Update lca0 login url

### DIFF
--- a/docs/cloud/aws/index.md
+++ b/docs/cloud/aws/index.md
@@ -14,7 +14,7 @@ The Cloud Foundations team currently supports two landing zones, **LCA0** and **
 
 You received a url to log into your AWS account as part of your onboarding.
 
-If you login via [http://bit.ly/OIT-AWS](http://bit.ly/OIT-AWS) or [https://fedauth.colorado.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices](https://fedauth.colorado.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices), your are using **LCA0**.
+If you login via [https://buff.link/aws](https://buff.link/aws) or [https://fedauth.colorado.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices](https://fedauth.colorado.edu/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices), your are using **LCA0**.
 
 If you login via [https://aws.colorado.edu/](https://aws.colorado.edu/), you are using **LCA1**.
 

--- a/docs/cloud/aws/lca0/faq/faq.md
+++ b/docs/cloud/aws/lca0/faq/faq.md
@@ -7,7 +7,7 @@ If you are looking for help with specific errors, please visit the [Troubleshoot
 
 ## What is the URL for the Single Sign-On Console?
 **Answer:**
-Login using your [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey) [here:](http://bit.ly/OIT-AWS).
+Login using your [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey) [here:](https://buff.link/aws).
 
 
 ## Why can't I see the AWS resources I created?

--- a/docs/cloud/aws/lca0/getting-started/aws-console-access.md
+++ b/docs/cloud/aws/lca0/getting-started/aws-console-access.md
@@ -8,11 +8,11 @@ Visit OIT's [DUO Multi-Factor Remote Access](https://oit.colorado.edu/services/i
 
 ## Single Sign-On
 
-Users access the [AWS Management Console](http://bit.ly/OIT-AWS) using their [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey).
-The Single Sign-On (SSO) URL is [http://bit.ly/OIT-AWS](http://bit.ly/OIT-AWS).
+Users access the [AWS Management Console](https://buff.link/aws) using their [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey).
+The Single Sign-On (SSO) URL is [https://buff.link/aws](https://buff.link/aws).
 You can access your AWS Account from anywhere with internet access.  You do not need to have a VPN connection to campus.
 
-1. Launch the [AWS Management Console (SSO URL)](http://bit.ly/OIT-AWS).
+1. Launch the [AWS Management Console (SSO URL)](https://buff.link/aws).
 2. Provide your [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey) credentials.
 ![](images/aws-console-access/login.png)
 3. Choose a method for authentication.  We recommend you select "Send Me a Push".  **NOTE:** You may not see the MFA step if you've recently authenticated and have an active session.

--- a/docs/cloud/aws/lca0/getting-started/customer-support.md
+++ b/docs/cloud/aws/lca0/getting-started/customer-support.md
@@ -10,7 +10,7 @@ See below on how to obtain your AWS Account Number.
 
 **How to Get your AWS Account Number and Current Support Plan**
 
-1. The AWS Account Number and Support Plan can be found by logging in to the AWS Console using your [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey) here: [http://bit.ly/OIT-AWS](http://bit.ly/OIT-AWS).
+1. The AWS Account Number and Support Plan can be found by logging in to the AWS Console using your [CU IdentiKey](https://oit.colorado.edu/services/identity-access-management/identikey) here: [https://buff.link/aws](https://buff.link/aws).
 2. Navigate to the [AWS Support Center](https://console.aws.amazon.com/support). In the upper left corner, the Account Number and Support Plan is shown.  **NOTE:** It is expected that you will see the error shown in the screen capture below.
 ![](images/customer-support/support-level.jpeg)
 


### PR DESCRIPTION
This PR updates LCA0 login URL from http://bit.ly/OIT-AWS to https://buff.link/aws (A more customer-friendly URL within CU managed domain)