### PR TITLE
Include Troubleshooting Bullitpoint for Newer Macs

### DIFF
--- a/docs/additional-resources/amc_ssh_auth.md
+++ b/docs/additional-resources/amc_ssh_auth.md
@@ -122,6 +122,13 @@ Log in at [registry.cilogon.org](https://registry.cilogon.org/registry/) and nav
 
 * If you are able to get through [Step 3](#step-3-upload-your-ssh-key-to-registrycilogonorg) but unable to ssh in from your terminal, check that the ssh key in your command is the same key you uploaded to the registry.
 * If you are prompted for a **__passphrase__** (not a password) when signing in from your terminal, this refers to the passphrase you set when you generated your ssh key. If you don't remember it then you will have to generate and upload a new ssh key to the registry. If you are prompted for a **__password__**, please submit a [support request form](https://colorado.service-now.com/req_portal?id=ucb_sc_rc_form), as this indicates an issue with your CILogon enrollment. Please include a screenshot of the error message and the date/time of your last login attempt.
+* FOR NEWER MACs: Certain newer mac OS's require the "rsa" key be manually made acceptable. You can do this by adding the following lines to your .ssh/config file (if the file does not yet exist, you can run `touch ~/.ssh/config` from a command line to create the file):
+```
+Host *
+HostkeyAlgorithms +ssh-rsa
+PubkeyAcceptedAlgorithms +ssh-rsa
+```
+
 * If you receive an error message indicating that you are not in the COmanage registry (see screenshot below), please submit a [support request form](https://colorado.service-now.com/req_portal?id=ucb_sc_rc_form).
 
 ![](./amc_ssh_images/notregistered_error.png)


### PR DESCRIPTION
Newer Mac OS's take issue with the "rsa" key type, and need an addition to their .ssh/config file for rsa to work on their systems