### PR TITLE
Remove AWS/CFS New Account Days from schedule

### DIFF
--- a/docs/getting_started/trainings_and_consults/current-sem-trainings.md
+++ b/docs/getting_started/trainings_and_consults/current-sem-trainings.md
@@ -17,7 +17,6 @@ Click the name of a training to view more details and register!
 
 ### **September 2026**
 - [Getting Started with Research Computing: From Command Line to Job Scheduling (A Short Course)](https://calendar.colorado.edu/event/getting-started-with-research-computing-from-command-line-to-job-scheduling-a-short-course-6841) - **September 2, 11am, Virtual (Zoom)**
-- AWS/CFS New Account Days (***Registration link coming soon!***) - **September 3, 2pm, Virtual (Zoom)**
 - [Lunch-n-Learn: Supercharge Your Python with Dask (A Quick Byte)](https://calendar.colorado.edu/event/lunch-n-learn-supercharge-your-python-with-dask-a-quick-byte) - **September 8, 11am, Virtual (Zoom)**
 - [Applied Containerization for Machine Learning in HPC (A Short Course)](https://calendar.colorado.edu/event/applied-containerization-for-machine-learning-in-hpc-a-short-course) - **September 9, 11am, Virtual (Zoom)**
 - [Lunch-n-Learn: Sharing Data Across Institutions with PetaLibrary and Globus (A Quick Byte)](https://calendar.colorado.edu/event/lunch-n-learn-sharing-data-across-institutions-with-petalibrary-and-globus-a-quick-byte) - **September 11, 11am, Virtual (Zoom)**
@@ -59,9 +58,6 @@ Click the name of a training to view more details and register!
 - [Setting up LLMs on CURC Resources (A Short Course)](https://calendar.colorado.edu/event/setting-up-llms-on-curc-resources-a-short-course) - **October 1, 11am, Virtual (Zoom)**
 - [AI Data Readiness Workshop (A Primer)](https://calendar.colorado.edu/event/ai-data-readiness-workshop-a-primer) - **November 5, 10am, Virtual (Zoom)**
 
-### **AWS**
-- AWS/CFS New Account Days (***Registration link coming soon!***) - **September 3, 2pm, Virtual (Zoom)**
-
 ````
 
 ````{tab-item} By Difficulty
@@ -71,7 +67,6 @@ Click the name of a training to view more details and register!
 - [HPC Microcredential](https://calendar.colorado.edu/event/hpc-microcredential) - **August 10-12, 9am, Hybrid (Norlin Library E206/Zoom)**
 - [Alpine New User Seminar (A Primer)](https://calendar.colorado.edu/event/alpine-new-user-seminar-a-primer) - **Wednesday, August 26, 10am, Virtual (Zoom)**
 - [Getting Started with Research Computing: From Command Line to Job Scheduling (A Short Course)](https://calendar.colorado.edu/event/getting-started-with-research-computing-from-command-line-to-job-scheduling-a-short-course-6841) - **September 2, 11am, Virtual (Zoom)**
-- AWS/CFS New Account Days (***Registration link coming soon!***) - **September 3, 2pm, Virtual (Zoom)**
 - [Lunch-n-Learn: Sharing Data Across Institutions with PetaLibrary and Globus (A Quick Byte)](https://calendar.colorado.edu/event/lunch-n-learn-sharing-data-across-institutions-with-petalibrary-and-globus-a-quick-byte) - **September 11, 11am, Virtual (Zoom)**
 
 ### **Intermediate**


### PR DESCRIPTION
Removed 'AWS/CFS New Account Days' event from the September schedule.