### PR TITLE
Review of AI/ML Section

### DIFF
--- a/docs/ai-ml/ai-resources.md
+++ b/docs/ai-ml/ai-resources.md
@@ -13,11 +13,12 @@
 - For a complete list of current semester offerings, see [CURC Trainings Page](../getting_started/trainings_and_consults/current-sem-trainings.md).
 ### CURC AI/ML Software Stack
 - The following AI/ML software are available and actively supported on CURC systems:
-    * Ollama: A lightweight and beginner-friendly tool for running large language models locally. Compatible with a variety of systems and enables easy model retrieval. For usage instructions, see [Running Large Language Models](./llms.md#ollama).
-    * Transformers by Hugging Face: A popular framework for working with pre-trained LLMs and building Natural Language Processing(NLP) applications. For usage instructions, see [Running Large Language Models](./llms.md#transformers-by-hugging-face).
+    * Ollama: A lightweight and beginner-friendly tool for running large language models locally. Compatible with a variety of systems and enables easy model retrieval. For usage instructions, see our [Ollama](./llms.md#ollama) documentation.
+        * In addition to the Ollama module, we have an easy to use LLM chat interface within Open OnDemand that utilizes Ollama. For more information, see our [LLM Chat Interface](../open_ondemand/llm_chat_interface.md) documentation. 
+    * Transformers by Hugging Face: A popular framework for working with pre-trained LLMs and building Natural Language Processing(NLP) applications. For usage instructions, see our [Transformers by Hugging Face](./llms.md#transformers-by-hugging-face) documentation.
     * AlphaFold: An AI tool from DeepMind that predicts 3D protein structures from amino acid sequences, revolutionizing biological and medical research. For documentation and usage details, see our [AlphaFold Page](../software/alphafold.md). 
     * CUDA Toolkit, cuDNN, NVIDIA HPC SDK: For GPU-accelerated AI training and inference.
-- Additional supported software can be found in the [CURC Software List](../software/curc_provided_software.md) or you can explore available modules using the `module spider` command.
+- Additional supported software can be found in the [CURC-Provided Software page](../software/curc_provided_software.md) or you can explore available modules using the `module spider` command.
 
 ## National Community Resources
 

--- a/docs/ai-ml/ai-resources.md
+++ b/docs/ai-ml/ai-resources.md
@@ -15,7 +15,7 @@
 - The following AI/ML software are available and actively supported on CURC systems:
     * Ollama: A lightweight and beginner-friendly tool for running large language models locally. Compatible with a variety of systems and enables easy model retrieval. For usage instructions, see our [Ollama](./llms.md#ollama) documentation.
         * In addition to the Ollama module, we have an easy to use LLM chat interface within Open OnDemand that utilizes Ollama. For more information, see our [LLM Chat Interface](../open_ondemand/llm_chat_interface.md) documentation. 
-    * Transformers by Hugging Face: A popular framework for working with pre-trained LLMs and building Natural Language Processing(NLP) applications. For usage instructions, see our [Transformers by Hugging Face](./llms.md#transformers-by-hugging-face) documentation.
+    * Transformers by Hugging Face: A popular framework for working with pre-trained LLMs and building Natural Language Processing (NLP) applications. For usage instructions, see our [Transformers by Hugging Face](./llms.md#transformers-by-hugging-face) documentation.
     * AlphaFold: An AI tool from DeepMind that predicts 3D protein structures from amino acid sequences, revolutionizing biological and medical research. For documentation and usage details, see our [AlphaFold Page](../software/alphafold.md). 
     * CUDA Toolkit, cuDNN, NVIDIA HPC SDK: For GPU-accelerated AI training and inference.
 - Additional supported software can be found in the [CURC-Provided Software page](../software/curc_provided_software.md) or you can explore available modules using the `module spider` command.

--- a/docs/ai-ml/llms.md
+++ b/docs/ai-ml/llms.md
@@ -107,7 +107,7 @@ In this section, we provide instructions for obtaining access to common LLM fram
 
 In this tab, we provide instructions for using our system installed Ollama. Although these instructions greatly simplify the steps needed to use Ollama, the system installed Ollama or provided API may not fit your needs. If you need to install a different version of Ollama or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-ollama=ollama-indepth#tabset-ref-ollama){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to either the `aa100` or `atesting_a100` partition). For the purposes of this tutorial, we will start an interactive session on the `atesting_a100` partition.
+To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -165,12 +165,12 @@ After execution, these commands should create a `bin` and `lib` directory contai
 
 ## Setting up the Ollama install 
 
-Now that we have Ollama installed, we need to start up an Ollama server on an NVIDIA GPU compute node (i.e. submitting a job to either the `aa100` or `atesting_a100` partition). We will then be able to interact with Ollama and our LLMs from the command line. For the purposes of this tutorial, we will start an interactive session on the `atesting_a100` partition:
+Now that we have Ollama installed, we need to start up an Ollama server on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). We will then be able to interact with Ollama and our LLMs from the command line. For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs:
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
 ```{important}
-For non-testing workflows, users should request NVIDIA GPUs using the `aa100` partition. 
+For non-testing workflows, users should request NVIDIA GPUs using one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions).
 ```
 
 Now that we have a session started, we will export important environment variables using the `ollama_v` variable we established in the previous section. 
@@ -300,7 +300,7 @@ This of course is just a simple example showing how one can query Ollama models 
 
 In this tab, we provide instructions for using our system installed Transformers. Although these instructions greatly simplify the steps needed to use Transformers, the system installed Transformers and associated libraries may not fit your needs. If you need to install a different version or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-hf-transformers=hf-transformers-indepth#tabset-ref-hf-transformers){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to either the `aa100` or `atesting_a100` partition). For the purposes of this tutorial, we will start an interactive session on the `atesting_a100` partition.
+To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -367,7 +367,7 @@ After you have your account set up, you can search models using the [Hugging Fac
 Depending on the model, it can take 30 minutes or more to get access to the model once you have accepted the terms of use. 
 ```
 
-At this point, all necessary libraries should be installed in either your custom environment or CURC's provided environment and we can begin downloading the LLMs we would like to run. If you are using our Transformers module, `HF_HOME` and `HF_HUB_CACHE` will point to your project's directory, ensuring that your home directory does not fill up. If you are not using our module, be sure these variables are appropriately set before proceeding. There are several ways to install a model, however, we often suggest that you use the `huggingface-cli`. For more in-depth information about `huggingface-cli` (such as how to view models and delete them) see [Command Line Interface (CLI)](https://huggingface.co/docs/huggingface_hub/en/guides/cli#command-line-interface-cli). The [hf cache scan](https://huggingface.co/docs/huggingface_hub/en/guides/cli#hf-cache-scan) and [hf cache delete](https://huggingface.co/docs/huggingface_hub/en/guides/cli#hf-cache-delete) sections are particularly useful for managing models.
+At this point, all necessary libraries should be installed in either your custom environment or CURC's provided environment and we can begin downloading the LLMs we would like to run. If you are using our Transformers module, `HF_HOME` and `HF_HUB_CACHE` will point to your project's directory, ensuring that your home directory does not fill up. If you are not using our module, be sure these variables are appropriately set before proceeding. There are several ways to install a model, however, we often suggest that you use the `huggingface-cli`. For more in-depth information about `huggingface-cli` (such as how to view models and delete them) see [Command Line Interface (CLI)](https://huggingface.co/docs/huggingface_hub/en/guides/cli#command-line-interface-cli).
 
 Once the `huggingface-cli` is available, you can set up your token associated with our system using the following
 ```
@@ -398,7 +398,7 @@ After this installation completes, you will then have access to your installed m
 
 In this section, we assume that you have installed all necessary libraries and the model you would like to run (or are using our module and provided models). Additionally, we assume you are on an NVIDIA GPU compute node. Please note that the below instructions are just one possible way to run an LLM using Transformers. There are also other methods, such as [Pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines#pipelines) that exist. 
 
-Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, our `atesting_a100` partition only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
+Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, our testing A100 GPU only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
 
 
 (tabset-ref-transformers-run)=
@@ -408,7 +408,7 @@ Now that we are ready to run our LLM, there is one last important consideration 
 ````{tab-item} No quantization
 :sync: transformers-run-no-quant
 
-In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it nicely fits on one of our `atesting_a100` GPUs. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
+In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it nicely fits on one of our testing A100 GPUs. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import os 
@@ -467,7 +467,7 @@ of salt to amplify
 ````{tab-item} Applying Quantization 
 :sync: transformers-run-quant
 
-In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on our `atesting_a100` GPUs. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
+In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on the testing A100 GPUs. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
 
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig

--- a/docs/ai-ml/llms.md
+++ b/docs/ai-ml/llms.md
@@ -107,7 +107,7 @@ In this section, we provide instructions for obtaining access to common LLM fram
 
 In this tab, we provide instructions for using our system installed Ollama. Although these instructions greatly simplify the steps needed to use Ollama, the system installed Ollama or provided API may not fit your needs. If you need to install a different version of Ollama or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-ollama=ollama-indepth#tabset-ref-ollama){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs.
+To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -169,7 +169,7 @@ After execution, these commands should create a `bin` and `lib` directory contai
 
 ## Setting up the Ollama install 
 
-Now that we have Ollama installed, we need to start up an Ollama server on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). We will then be able to interact with Ollama and our LLMs from the command line. For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs:
+Now that we have Ollama installed, we need to start up an Ollama server on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). We will then be able to interact with Ollama and our LLMs from the command line. For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing:
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -304,7 +304,7 @@ This of course is just a simple example showing how one can query Ollama models 
 
 In this tab, we provide instructions for using our system installed Transformers. Although these instructions greatly simplify the steps needed to use Transformers, the system installed Transformers and associated libraries may not fit your needs. If you need to install a different version or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-hf-transformers=hf-transformers-indepth#tabset-ref-hf-transformers){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For the purposes of this tutorial, we will start an interactive session on one of our testing A100 GPUs.
+To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -402,7 +402,7 @@ After this installation completes, you will then have access to your installed m
 
 In this section, we assume that you have installed all necessary libraries and the model you would like to run (or are using our module and provided models). Additionally, we assume you are on an NVIDIA GPU compute node. Please note that the below instructions are just one possible way to run an LLM using Transformers. There are also other methods, such as [Pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines#pipelines) that exist. 
 
-Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, our testing A100 GPU only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
+Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, our A100 GPU designated for testing only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
 
 
 (tabset-ref-transformers-run)=
@@ -412,7 +412,7 @@ Now that we are ready to run our LLM, there is one last important consideration 
 ````{tab-item} No quantization
 :sync: transformers-run-no-quant
 
-In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it nicely fits on one of our testing A100 GPUs. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
+In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it fits comfortably on one of our A100 GPUs designated for testing. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import os 
@@ -471,7 +471,7 @@ of salt to amplify
 ````{tab-item} Applying Quantization 
 :sync: transformers-run-quant
 
-In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on the testing A100 GPUs. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
+In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on one of our A100 GPUs designated for testing. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
 
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig

--- a/docs/ai-ml/llms.md
+++ b/docs/ai-ml/llms.md
@@ -107,7 +107,7 @@ In this section, we provide instructions for obtaining access to common LLM fram
 
 In this tab, we provide instructions for using our system installed Ollama. Although these instructions greatly simplify the steps needed to use Ollama, the system installed Ollama or provided API may not fit your needs. If you need to install a different version of Ollama or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-ollama=ollama-indepth#tabset-ref-ollama){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing.
+To begin, we first need to start a job on one of the [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions). For this tutorial, we’ll start an interactive session on one of the A100 GPUs designated for testing.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -169,12 +169,12 @@ After execution, these commands should create a `bin` and `lib` directory contai
 
 ## Setting up the Ollama install 
 
-Now that we have Ollama installed, we need to start up an Ollama server on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). We will then be able to interact with Ollama and our LLMs from the command line. For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing:
+Now that we have Ollama installed, we need to start an Ollama server on one of the [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions). We will then be able to interact with Ollama and our LLMs from the command line. For this tutorial, we’ll start an interactive session on one of the A100 GPUs designated for testing:
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
 ```{important}
-For non-testing workflows, users should request NVIDIA GPUs using one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions).
+For non-testing workflows, users should request NVIDIA GPUs on one of the [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions).
 ```
 
 Now that we have a session started, we will export important environment variables using the `ollama_v` variable we established in the previous section. 
@@ -304,7 +304,7 @@ This of course is just a simple example showing how one can query Ollama models 
 
 In this tab, we provide instructions for using our system installed Transformers. Although these instructions greatly simplify the steps needed to use Transformers, the system installed Transformers and associated libraries may not fit your needs. If you need to install a different version or need to customize the provided environment, you will need to follow the instructions in the [Self-install instructions tab](?tabset-hf-transformers=hf-transformers-indepth#tabset-ref-hf-transformers){.external}. 
 
-To begin, we first need to jump on an NVIDIA GPU compute node (i.e. submitting a job to one of our [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions)). For this tutorial, we’ll start an interactive session on one of our A100 GPUs designated for testing.
+To begin, we first need to start a job on one of the [NVIDIA GPU partitions](../clusters/alpine/alpine-hardware.md#partitions). For this tutorial, we’ll start an interactive session on one of the A100 GPUs designated for testing.
 ```
 sinteractive --partition=aa100 --qos=gpu-testing --nodes=1 --gres=gpu:a100_3g.20gb:1 --ntasks=10 --time=01:00:00
 ```
@@ -402,7 +402,7 @@ After this installation completes, you will then have access to your installed m
 
 In this section, we assume that you have installed all necessary libraries and the model you would like to run (or are using our module and provided models). Additionally, we assume you are on an NVIDIA GPU compute node. Please note that the below instructions are just one possible way to run an LLM using Transformers. There are also other methods, such as [Pipelines](https://huggingface.co/docs/transformers/en/main_classes/pipelines#pipelines) that exist. 
 
-Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, our A100 GPU designated for testing only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
+Now that we are ready to run our LLM, there is one last important consideration we need to make before running the model: whether to quantize the LLM. Many models provided on Hugging Face are not quantized, and for this reason, are very large. Depending on the GPU you are using, this can be a big problem because you may not have enough space on the GPU's VRAM. For example, the A100 GPU designated for testing only provides 20 GB of GPU memory (VRAM), which is often too small for medium-sized models that have not been quantized. When this is the case, we often want to perform [Quantization](https://huggingface.co/docs/transformers/v4.56.2/quantization/overview) to reduce the memory footprint. Below we provide an example where we do not utilize quantization and one where we do.  
 
 
 (tabset-ref-transformers-run)=
@@ -412,7 +412,7 @@ Now that we are ready to run our LLM, there is one last important consideration 
 ````{tab-item} No quantization
 :sync: transformers-run-no-quant
 
-In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it fits comfortably on one of our A100 GPUs designated for testing. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
+In this tab, we run our `gpt-oss-20b` model without quantization. Quantization is not needed for this model, as by default, the model obtained from Hugging Face has been quantized using the MXFP4 format. Additionally, it fits comfortably on one of the A100 GPUs designated for testing. To run the `gpt-oss-20b` model without quantization let's create the following script named `transformers_run_no_quant.py`:
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM
 import os 
@@ -471,7 +471,7 @@ of salt to amplify
 ````{tab-item} Applying Quantization 
 :sync: transformers-run-quant
 
-In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on one of our A100 GPUs designated for testing. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
+In this tab, we run our `Llama-3.1-8B-Instruct` model with quantization. Quantization is needed for this model if we want to run it on one of the A100 GPUs designated for testing. Here we will utilize QLoRA or 4-bit quantization. To run `Llama-3.1-8B-Instruct` with quantization, let's create the following script named `transformers_run_quant.py`:
 
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM, BitsAndBytesConfig

--- a/docs/ai-ml/llms.md
+++ b/docs/ai-ml/llms.md
@@ -128,6 +128,10 @@ module load uv
 source $CURC_UV_ENV_DIR/ollama-python-api-env/bin/activate
 ``` 
 
+:::{seealso}
+Do you prefer a Graphical User Interface when interacting with Ollama provided LLMs? Checkout our Open OnDemand [LLM Chat Interface](../open_ondemand/llm_chat_interface.md)!
+:::
+
 ````
 
 ````{tab-item} Self-install instructions


### PR DESCRIPTION
In this PR I modify items that were found to be outdated or do not completely align with our accessibility guidelines. In addition to making sure that all links were accessible, I also:
- Clarified the ollama/hf/software markdown references in the `AI Trainings and Resources Guide` page so that they are up-to-date and reflect the content they point to
- Added a bullet for our new LLM chat interface in the `AI Trainings and Resources Guide` page
- Modify references to the old `atesting_a100` partition in the `Running Large Language Models` page so that it correctly identifies them as A100 testing resources 
- Added a seealso admonition for Ollama pointing to our OOD application in the `Running Large Language Models` page
- Deleted references to `hf cache scan` and `hf cache delete` in the `Running Large Language Models` page. It seems like these commands are no longer used. 